### PR TITLE
[fix] SecurityConfig와 SwaggerConfig의 충돌문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.1.4'
+	id 'io.spring.dependency-management' version '1.1.3'
+
 }
 
 group = 'com.bigpicture'
@@ -24,30 +25,36 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot 기본 웹 기능
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	//JPA
+	// JPA (Hibernate 포함)
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	// 유효성 검사
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// Security
+	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	// jwt
+	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// OpenAPI (Swagger)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// MySQL 드라이버
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	//openAPI
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	// 테스트 관련
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bigpicture/moonrabbit/domain/playlist/dto/PlaylistRequestDto.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/playlist/dto/PlaylistRequestDto.java
@@ -1,10 +1,12 @@
 package com.bigpicture.moonrabbit.domain.playlist.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class PlaylistRequestDto {
     private String title;
     private String videoUrl;

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/LoginRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/LoginRequestDTO.java
@@ -4,11 +4,13 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequestDTO {
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UserResponseDTO.java
@@ -3,8 +3,10 @@ package com.bigpicture.moonrabbit.domain.user.dto;
 import com.bigpicture.moonrabbit.domain.user.entity.User;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserResponseDTO {
     private String email;
     private String nickname;

--- a/src/main/java/com/bigpicture/moonrabbit/global/config/SecurityConfig.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/config/SecurityConfig.java
@@ -27,15 +27,26 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+
                 // JWT를 사용하기 때문에 세션을 사용하지 않음
-                .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
-                                   .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 .authorizeHttpRequests(authorize -> authorize
+                        // Swagger 관련 경로 열어두기
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+
                         // 해당 API에 대해서는 모든 요청을 허가
-                        //  .requestMatchers("경로", "경로").permitAll()
+                        // .requestMatchers("경로", "경로").permitAll()
 
                         // 이 밖에 모든 요청에 대해서 인증을 필요로 한다는 설정
-                        .anyRequest().permitAll())
+                        .anyRequest().permitAll()
+                )
 
                 // JWT 인증을 위하여 직접 구현한 필터를 UsernamePasswordAuthenticationFilter 전에 실행
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
@@ -50,4 +61,3 @@ public class SecurityConfig {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }
-

--- a/src/main/java/com/bigpicture/moonrabbit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.bigpicture.moonrabbit.global.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -12,9 +13,11 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     // 커스텀 예외 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ex.printStackTrace();
         ErrorCode errorCode = ex.getErrorCode();
         ErrorResponse response = new ErrorResponse(errorCode);
         return new ResponseEntity<>(response, errorCode.getStatus());
@@ -23,6 +26,7 @@ public class GlobalExceptionHandler {
     // 입력값 검증 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        ex.printStackTrace();
         BindingResult bindingResult = ex.getBindingResult();
         Map<String, String> errors = new HashMap<>();
 
@@ -35,7 +39,15 @@ public class GlobalExceptionHandler {
 
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex, HttpServletRequest request) {
+        ex.printStackTrace();
+        String uri = request.getRequestURI();
+
+        // Swagger 관련 요청은 예외 재던짐
+        if (uri.startsWith("/v3/api-docs") || uri.startsWith("/swagger-ui")) {
+            throw new RuntimeException(ex); // 또는 throw ex;
+        }
+
         ErrorResponse response = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, ErrorCode.INTERNAL_SERVER_ERROR.getStatus());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,7 @@ server.address=0.0.0.0
 
 # jwt token
 jwt.secret =${JWT_SECRET}
+
+# Swagger
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
# [fix] SecurityConfig와 SwaggerConfig의 충돌문제 수정

## 😺 Issue
- #22 

## ✅ 작업 리스트
- SecurityConfig에서 Swagger 관련 요청을 차단하는 버그 수정
- 컨트롤러간의 순환참조 확인
- 기본 생성자가 없는 클래스들에 @NoArgsConstructor를 추가
- 예외처리시 디버깅용 코드 추가
- SpringBoot와 Spring 버전 충돌 수정

## ⚙️ 작업 내용
- SecurityConfig에 Swagger관련 경로 허용 추가
- 컨트롤러(User와 Playlist)간의 순환참조 확인
- 혹시 몰라서 application.properties에 `springdoc.api-docs.enabled=true
springdoc.swagger-ui.enabled=true
`이런 식의 명시적 허용 추가
- 예외처리시에 `ex.printStackTrace();` 를 추가하여 디버깅에 사용 
- SpringBoot 버전과 Spring 버전이 충돌난 것을 확인. build.gradle 파일에서 버전 수정 1

## 📷 테스트 / 구현 내용
![image](https://github.com/user-attachments/assets/bdd1bd5c-b7fc-4a3d-a3c7-51d328c9553f)