### PR TITLE
[feat] 구글 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/entity/User.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/entity/User.java
@@ -1,20 +1,15 @@
 package com.bigpicture.moonrabbit.domain.user.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User {
     private static final String ROLE_USER = "USER";
     private static final String ROLE_ADMIN = "ADMIN";
@@ -23,16 +18,15 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-
     @Column(nullable = false)
     private String email;
-
 
     @Column(nullable = true)
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
             message = "비밀번호는 최소 8자 이상이어야 하며, 적어도 하나의 영문자와 하나의 특수 문자를 포함해야 합니다.")
     private String password;
-
+    private String provider;
+    private String providerId;
     private String nickname;
     private String profileImg;
     private String role = ROLE_USER;

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/jwt/provider/JwtProvider.java
@@ -78,4 +78,18 @@ public class JwtProvider {
             return e.getClaims();
         }
     }
+    public String createToken(String email, String role) {
+        // 토큰 유효시간 설정 (예: 1시간)
+        long now = System.currentTimeMillis();
+        long validity = 1000 * 60 * 60;
+
+        return Jwts.builder()
+                .setSubject(email) // 사용자 이메일을 sub에 저장
+                .claim("auth", role) // 권한은 커스텀 claim으로 저장
+                .setIssuedAt(new java.util.Date(now))
+                .setExpiration(new java.util.Date(now + validity))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
 }

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,33 @@
+package com.bigpicture.moonrabbit.global.auth.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final String role;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(nameAttributeKey).toString();
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2UserService.java
@@ -1,4 +1,50 @@
 package com.bigpicture.moonrabbit.global.auth.oauth2;
 
-public class CustomOAuth2UserService {
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import com.bigpicture.moonrabbit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 기본 사용자 정보 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 2. 제공자 정보
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // ex: "google"
+        String providerId = (String) attributes.get("sub"); // Google은 sub가 고유 ID
+        String email = (String) attributes.get("email");
+        String name = (String) attributes.get("name");
+        String picture = (String) attributes.get("picture");
+
+        // 3. 이메일 기준으로 기존 사용자 조회
+        User user = userRepository.findByEmail(email).orElseGet(() ->
+                userRepository.save(User.builder()
+                        .email(email)
+                        .nickname(name)
+                        .profileImg(picture)
+                        .provider(provider)
+                        .providerId(providerId)
+                        .role("USER")
+                        .build())
+        );
+
+        // 4. 인증된 사용자 반환
+        return new CustomOAuth2User(user.getRole(), attributes, "sub");
+    }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,4 @@
+package com.bigpicture.moonrabbit.global.auth.oauth2;
+
+public class CustomOAuth2UserService {
+}

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,4 @@
+package com.bigpicture.moonrabbit.global.auth.oauth2.handler;
+
+public class OAuth2LoginSuccessHandler {
+}

--- a/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,4 +1,43 @@
 package com.bigpicture.moonrabbit.global.auth.oauth2.handler;
 
-public class OAuth2LoginSuccessHandler {
+import com.bigpicture.moonrabbit.global.auth.jwt.provider.JwtProvider;
+import com.bigpicture.moonrabbit.global.auth.oauth2.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        String email = (String) oAuth2User.getAttributes().get("email");
+        String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
+
+        // JWT 토큰 생성
+        String token = jwtProvider.createToken(email, role);
+
+        // 토큰을 쿼리 파라미터로 리다이렉트
+        String redirectUri = "http://localhost:8080/oauth2/redirect?token=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+
+        log.info("OAuth2 login success. Redirecting to: {}", redirectUri);
+        response.sendRedirect(redirectUri);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ oauth.kakao.user-info-url=https://kapi.kakao.com/v2/user/me
 
 # Google
 spring.security.oauth2.client.registration.google.client-id=1011388010749-8vchrm0graq3qa18aqqgcsi5gei056tb.apps.googleusercontent.com
-spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_SECRET}
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
 spring.security.oauth2.client.registration.google.scope=email,profile
 spring.security.oauth2.client.provider.google.user-name-attribute=sub

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,12 @@ oauth.kakao.redirect-uri=http://localhost/oauth/kakao/callback
 oauth.kakao.token-url=https://kauth.kakao.com/oauth/token
 oauth.kakao.user-info-url=https://kapi.kakao.com/v2/user/me
 
+# Google
+spring.security.oauth2.client.registration.google.client-id=1011388010749-8vchrm0graq3qa18aqqgcsi5gei056tb.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.scope=email,profile
+spring.security.oauth2.client.provider.google.user-name-attribute=sub
 # Server
 server.address=0.0.0.0
 


### PR DESCRIPTION
# [feat] 구글 회원가입 구현

## 😺 Issue
- #24 

## ✅ 작업 리스트
- 구글 회원가입 구현
- 구글 클라우드 콘솔 프로젝트 생성

## ⚙️ 작업 내용
- 시큐리티 콘피그 내용 추가 
- oauth2 라이브러리 추가
- User 엔티티 수정 ( 구글, 카카오 구분 및 식별아이디 저장 용도 )

## 📷 테스트 / 구현 내용
### 구글 로그인은 포스트맨으로 구현이 힘들어 직접 브라우저에 입력, DB에 저장되는 것까지 확인함
- http://localhost:8080/oauth2/authorization/google (Spring Security가 구글 로그인 페이지로 리다이렉트)
- 로그인 및 진행하면 redirectUrl로 연결 및 토큰발급 http://localhost:8080/oauth2/redirect?token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ2bG9laW9semxyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJpYXQiOjE3NDQwMjk2NjAsImV4cCI6MTc0NDAzMzI2MH0.EqtonNqyuIcLw79hISR1MYRp3VT2rugFvnYNdaH_OEA
- 사용자 DB에 저장
![image](https://github.com/user-attachments/assets/c0a21742-1ae3-4407-a1fd-45ec24c8050b)

## 🤔 문제점 / 궁금한 점 (필요 시)
- 카카오는 Security 적용 전에 구현해서 Security 내용 안들어감 ( ? ) 수정 필요

## 참고 사항 (필요 시)
-  Chat GPT가 아닌 내가 코드를 이해할 필요가 있으므로 이번주는 ERD 마무리하고 코드리뷰만 해야함
