### PR TITLE
[refactor] 게시글 생성 API 수정

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/dto/BoardResponseDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/dto/BoardResponseDTO.java
@@ -19,6 +19,8 @@ public class BoardResponseDTO {
     private String content;
     private String category;
     private List<AnswerResponseDTO> answers;
+    private String nickname;
+    private String profileImg;
 
 
     public BoardResponseDTO(Board board) {
@@ -30,5 +32,9 @@ public class BoardResponseDTO {
         this.answers = board.getAnswers().stream()
                 .map(AnswerResponseDTO::new)
                 .collect(Collectors.toList());
+        if (board.getUser() != null) {
+            this.nickname = board.getUser().getNickname();
+            this.profileImg = board.getUser().getProfileImg();
+        }
     }
 }


### PR DESCRIPTION
# [refactor] 게시글 생성 API 수정

## 😺 Issue
- #52 

## ✅ 작업 리스트
- 닉네임 반환
- 프로필 이미지 반환

## ⚙️ 작업 내용
- 유저데이터 null 아닐 시 response 엔티티에 반환값 추가

## 📷 테스트 / 구현 내용
![image](https://github.com/user-attachments/assets/62ac9410-bdc2-49b5-b94e-fec4c23badf6)
