### PR TITLE
[feat] 익명기능, 소셜로그인 예외 추가

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/dto/BoardRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/dto/BoardRequestDTO.java
@@ -1,5 +1,6 @@
 package com.bigpicture.moonrabbit.domain.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -17,7 +18,9 @@ public class BoardRequestDTO {
     @Schema(description = "분야", example = "전체, 가족, 연인 ...")
     private String category;
 
+
     @Schema(description = "익명여부", example = "false")
+    @JsonProperty("isAnonymous")
     private boolean isAnonymous;
 
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardServiceImpl.java
@@ -6,6 +6,7 @@ import com.bigpicture.moonrabbit.domain.board.entity.Board;
 import com.bigpicture.moonrabbit.domain.board.repository.BoardRepository;
 import com.bigpicture.moonrabbit.domain.user.entity.User;
 import com.bigpicture.moonrabbit.domain.user.repository.UserRepository;
+import com.bigpicture.moonrabbit.domain.user.service.UserService;
 import com.bigpicture.moonrabbit.global.exception.CustomException;
 import com.bigpicture.moonrabbit.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class BoardServiceImpl implements BoardService {
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
+    private final UserService userService;
 
     @Override
     public BoardResponseDTO createBoard(BoardRequestDTO boardDTO, Long userId) {
@@ -31,6 +33,9 @@ public class BoardServiceImpl implements BoardService {
         board.setCategory(boardDTO.getCategory());
         board.setAnonymous(boardDTO.isAnonymous());
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if(boardDTO.isAnonymous()) {
+            user.setNickname(userService.generateNickname());
+        }
         board.setUser(user);
         Board savedBoard = boardRepository.save(board);
         return new BoardResponseDTO(savedBoard);

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
@@ -83,4 +83,13 @@ public class UserController {
         User user = userService.getUserByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
         return ResponseEntity.ok(new UserResponseDTO(user));
     }
+
+    // 사용자 정보 반환 (익명)
+    @GetMapping("/nicknames/random")
+    @Operation(summary = "랜덤 닉네임 생성 API", description = "로그인된 사용자의 정보를 불러오지만 닉네임을 랜덤닉네임으로 불러옴   ")
+    public ResponseEntity<UserResponseDTO> getRandomNickname() {
+        User user = userService.getUserByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
+        user.setNickname(userService.generateNickname());
+        return ResponseEntity.ok(new UserResponseDTO(user));
+    }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
@@ -19,4 +19,6 @@ public interface UserService {
 
     // 유저 아이디 이메일로 찾기
     Long getUserIdByEmail(String email);
+
+    String generateNickname();
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserServiceImpl.java
@@ -73,11 +73,12 @@ public class UserServiceImpl implements UserService {
 
 
     // 이메일과 비밀번호로 로그인
-    @Override
     public JwtDTO login(String email, String password) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND)); // 사용자 존재 여부 확인
-
+        if(!(user.getProvider().equals("common"))) {
+            throw new CustomException(ErrorCode.USER_OTHER_PROVIDER);
+        }
         // 비밀번호 확인 (저장된 비밀번호와 입력받은 비밀번호 비교)
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD); // 비밀번호 불일치 시 예외 발생
@@ -94,11 +95,12 @@ public class UserServiceImpl implements UserService {
         return user.getId();
     }
 
+    @Override
     // 랜덤 닉네임 생성
-    static String generateNickname() {
+    public String generateNickname() {
         Random random = new Random();
-        String adjective = UserServiceImpl.ADJECTIVES[random.nextInt(UserServiceImpl.ADJECTIVES.length)];
-        String noun = UserServiceImpl.NOUNS[random.nextInt(UserServiceImpl.NOUNS.length)];
+        String adjective = ADJECTIVES[random.nextInt(ADJECTIVES.length)];
+        String noun = NOUNS[random.nextInt(NOUNS.length)];
         return adjective + noun;
     }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/global/config/SpringConfig.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/config/SpringConfig.java
@@ -50,8 +50,8 @@ public class SpringConfig {
     }
 
     @Bean
-    public BoardService boardService() {
-        return new BoardServiceImpl(boardRepository, userRepository);
+    public BoardService boardService(UserService userService) {
+        return new BoardServiceImpl(boardRepository, userRepository, userService());
     }
 
     @Bean

--- a/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U002", "해당 사용자를 찾을 수 없습니다."),
     PASSWORD_COFIRM_ERROR(HttpStatus.BAD_REQUEST, "U003", "입력한 비밀번호가 일치하지 않습니다."),
     USER_INCORRECT(HttpStatus.BAD_REQUEST, "U004", "작성자만 수정이 가능합니다."),
-
+    USER_OTHER_PROVIDER(HttpStatus.BAD_REQUEST, "U005", "이미 소셜 미디어로 연동하여 가입된 계정입니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "A001", "해당 댓글을 찾을 수 없습니다."),
     // 게시글 관련 에러
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "해당 게시글을 찾을 수 없습니다."),


### PR DESCRIPTION
# [feat] 익명기능, 소셜로그인 예외 추가

## 😺 Issue
- #58 

## ✅ 작업 리스트
- 사용자 정보 조회 시, 익명으로 정보 조회
- 게시글 작성 시 익명 기능 추가

## ⚙️ 작업 내용
- 사용자 정보 조회 시, 익명으로 정보 조회하는 API 추가
- 소셜로그인으로 가입한 이메일로 일반 로그인 시도 시, 예외 문구 추가하는 기능 추가
- 게시글 작성 시 익명 여부가 참이면 랜덤 닉네임으로 업로드 되도록 추가 (회원 id는 그대로임)

## 📷 테스트 / 구현 내용
<img width="768" height="383" alt="image" src="https://github.com/user-attachments/assets/af9c753f-da8d-46cc-b0ef-a9d470b82f77" />
<img width="689" height="393" alt="image" src="https://github.com/user-attachments/assets/6acb68cf-1852-42a0-8370-47d7fdf89d46" />
<img width="1367" height="746" alt="image" src="https://github.com/user-attachments/assets/a868b45d-5a50-4aae-baff-59c04847bb51" />



