### PR TITLE
[feat] 일일 질문 기능 구현

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/admin/controller/AdminController.java
@@ -5,6 +5,9 @@ import com.bigpicture.moonrabbit.domain.admin.dto.UserAdminResponseDTO;
 import com.bigpicture.moonrabbit.domain.admin.service.AdminService;
 import com.bigpicture.moonrabbit.domain.board.dto.BoardRequestDTO;
 import com.bigpicture.moonrabbit.domain.board.dto.BoardResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+    private final DailyQuestionService dailyQuestionService;
 
     @GetMapping("/users")
     @Operation(summary = "유저 목록 조회", description = "유저들의 목록을 조회하는 기능")

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/controller/AdminDailyQuestionController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/controller/AdminDailyQuestionController.java
@@ -1,0 +1,22 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.controller;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/daily-question")
+@RequiredArgsConstructor
+public class AdminDailyQuestionController {
+    private final DailyQuestionService dailyQuestionService;
+
+    @Operation(summary = "어드민 질문 생성", description = "관리자가 질문 생성")
+    @PostMapping("/api/admin/daily-questions")
+    public DailyQuestion createDailyQuestion(
+            @RequestBody DailyQuestionRequestDTO requestDTO) {
+        return dailyQuestionService.createOrReplaceForDate(requestDTO);
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/controller/DailyController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/controller/DailyController.java
@@ -1,0 +1,81 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.controller;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyAnswerHistoryResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyAnswerRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyAnswerResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyAnswerService;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionService;
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import com.bigpicture.moonrabbit.domain.user.repository.UserRepository;
+import com.bigpicture.moonrabbit.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/daily")
+@RequiredArgsConstructor
+public class DailyController {
+    private final DailyQuestionService dailyQuestionService;
+    private final DailyAnswerService dailyAnswerService;
+    private final UserService userService;
+
+    // 오늘의 질문 조회 (익명 접근 허용하면 인증 없어도)
+    @Operation(summary = "오늘의 질문 조회", description = "익명 접근 가능. 오늘의 DailyQuestion을 조회합니다.")
+    @GetMapping("/question")
+    public ResponseEntity<DailyQuestionResponseDTO> getTodayQuestion() {
+        DailyQuestion q = dailyQuestionService.getToday();
+        if (q == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(new DailyQuestionResponseDTO(q.getId(), q.getDate(), q.getContent()));
+    }
+
+    @Operation(summary = "오늘 질문에 답변 제출/수정", description = "인증 필요. DailyAnswer를 새로 제출하거나 기존 답변을 수정합니다.")
+    @PostMapping("/answer")
+    public ResponseEntity<DailyAnswerResponseDTO> submitAnswer(@RequestBody DailyAnswerRequestDTO request) {
+        DailyAnswerResponseDTO dto = dailyAnswerService.submitOrUpdateTodayAnswer(request.getAnswer());
+        return ResponseEntity.ok(dto);
+    }
+
+    @Operation(summary = "오늘 내가 쓴 답변 조회", description = "인증 필요. 사용자가 오늘 작성한 답변을 조회합니다.")
+    @GetMapping("/answer/me")
+    public ResponseEntity<DailyAnswerResponseDTO> getMyTodayAnswer() {
+        DailyAnswerResponseDTO dto = dailyAnswerService.getMyTodayAnswer();
+        if (dto == null) return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(dto);
+    }
+    @Operation(summary = "내 답변 히스토리 조회", description = "인증 필요. 페이징 가능하며 사용자가 작성한 DailyAnswer 리스트를 반환합니다.")
+    @GetMapping("/history")
+    public Page<DailyAnswerResponseDTO> getHistory(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        User currentUser = userService.getUserByEmail(email);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<DailyAnswer> answers = dailyAnswerService.getMyAnswerHistory(currentUser, pageable);
+
+        return answers.map(answer ->
+                new DailyAnswerResponseDTO(
+                        answer.getId(),
+                        answer.getDailyQuestion().getId(),
+                        answer.getDailyQuestion().getContent(),
+                        answer.getAnswer(),
+                        answer.getCreatedAt()
+                ));
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerHistoryResponseDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerHistoryResponseDTO.java
@@ -1,0 +1,17 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class DailyAnswerHistoryResponseDTO {
+    private Long questionId;
+    private LocalDate questionDate;
+    private String questionContent;
+    private String answerContent;
+    private LocalDateTime answeredAt;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerRequestDTO.java
@@ -1,0 +1,12 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyAnswerRequestDTO {
+    private String answer;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerResponseDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyAnswerResponseDTO.java
@@ -1,0 +1,18 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.dto;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class DailyAnswerResponseDTO {
+    private Long answerId;
+    private Long questionId;
+    private String questionContent;
+    private String answerContent;
+    private LocalDateTime answeredAt;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyQuestionRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyQuestionRequestDTO.java
@@ -1,0 +1,19 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyQuestionRequestDTO {
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate date;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyQuestionResponseDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/dto/DailyQuestionResponseDTO.java
@@ -1,0 +1,14 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class DailyQuestionResponseDTO {
+    private Long id;
+    private LocalDate date;
+    private String content;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/entity/DailyAnswer.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/entity/DailyAnswer.java
@@ -1,0 +1,44 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.entity;
+
+
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DailyAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 작성자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 질문 참조
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_question_id", nullable = false)
+    private DailyQuestion dailyQuestion;
+
+    @Column(nullable = false, length = 2000)
+    private String answer;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateAnswer(String newAnswer) {
+        this.answer = newAnswer;
+    } // User 엔티티는 프로젝트에 이미 있다고 가정합니다.
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/entity/DailyQuestion.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/entity/DailyQuestion.java
@@ -1,0 +1,27 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DailyQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/repository/DailyAnswerRepository.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/repository/DailyAnswerRepository.java
@@ -1,0 +1,19 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.repository;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyAnswerRepository extends JpaRepository<DailyAnswer,Long> {
+    // today 답변을 찾거나 (user + question)으로 확인할 때 사용
+    Optional<DailyAnswer> findByDailyQuestionIdAndUserId(Long dailyQuestionId, Long userId);
+
+    // User 객체 기준으로 페이징 조회, 생성일 내림차순
+    Page<DailyAnswer> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/repository/DailyQuestionRepository.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/repository/DailyQuestionRepository.java
@@ -1,0 +1,11 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.repository;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailyQuestionRepository extends JpaRepository<DailyQuestion,Long> {
+    Optional<DailyQuestion> findByDate(LocalDate date);
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/scheduler/DailyQuestionScheduler.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/scheduler/DailyQuestionScheduler.java
@@ -1,0 +1,33 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.scheduler;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DailyQuestionScheduler {
+    private final DailyQuestionService dailyQuestionService;
+
+    // 실제 운영: 매일 자정(서버 시간) 실행
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void createDailyQuestionAtMidnight() {
+        DailyQuestionRequestDTO dto = new DailyQuestionRequestDTO(
+                "오늘의 질문입니다.",
+                java.time.LocalDate.now()
+        );
+        dailyQuestionService.createOrReplaceForDate(dto);
+    }
+
+    // 테스트용: 1분마다 실행 (운영에서는 주석처리)
+    @Scheduled(cron = "0 */1 * * * ?")
+    public void createDailyQuestionEveryMinuteForTest() {
+        DailyQuestionRequestDTO dto = new DailyQuestionRequestDTO(
+                "테스트 질문(매분)",
+                java.time.LocalDate.now()
+        );
+        dailyQuestionService.createOrReplaceForDate(dto);
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyAnswerService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyAnswerService.java
@@ -1,0 +1,14 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.service;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyAnswerResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface DailyAnswerService {
+
+    public DailyAnswerResponseDTO submitOrUpdateTodayAnswer(String answerText);
+    public DailyAnswerResponseDTO getMyTodayAnswer();
+    public Page<DailyAnswer> getMyAnswerHistory(User currentUser, Pageable pageable);
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyAnswerServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyAnswerServiceImpl.java
@@ -1,0 +1,81 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.service;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyAnswerResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyAnswerRepository;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyQuestionRepository;
+import com.bigpicture.moonrabbit.domain.user.entity.User;
+import com.bigpicture.moonrabbit.domain.user.service.UserService;
+import com.bigpicture.moonrabbit.global.exception.CustomException;
+import com.bigpicture.moonrabbit.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+public class DailyAnswerServiceImpl implements DailyAnswerService{
+    private final DailyAnswerRepository dailyAnswerRepository;
+    private final DailyQuestionRepository dailyQuestionRepository;
+    private final UserService userService;
+
+    @Transactional
+    public DailyAnswerResponseDTO submitOrUpdateTodayAnswer(String answerText) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        User currentUser = userService.getUserByEmail(email);
+
+        LocalDate today = LocalDate.now();
+        DailyQuestion question = dailyQuestionRepository.findByDate(today)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+
+        // 이미 답변 존재하면 수정
+        DailyAnswer dailyAnswer = dailyAnswerRepository.findByDailyQuestionIdAndUserId(question.getId(), currentUser.getId())
+                .map(existing -> {
+                    existing.updateAnswer(answerText);
+                    return existing;
+                })
+                .orElseGet(() -> DailyAnswer.builder()
+                        .user(currentUser)
+                        .dailyQuestion(question)
+                        .answer(answerText)
+                        .createdAt(LocalDateTime.now())
+                        .build());
+
+        DailyAnswer saved = dailyAnswerRepository.save(dailyAnswer);
+        return new DailyAnswerResponseDTO(saved.getId(), question.getId(), question.getContent(), saved.getAnswer(), saved.getCreatedAt());
+    }
+
+    /**
+     * 오늘 자신이 쓴 답변 조회 (없으면 null 또는 예외 처리)
+     */
+    @Transactional(readOnly = true)
+    public DailyAnswerResponseDTO getMyTodayAnswer() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        User currentUser = userService.getUserByEmail(email);
+
+        LocalDate today = LocalDate.now();
+        DailyQuestion question = dailyQuestionRepository.findByDate(today)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+
+        DailyAnswer answer = dailyAnswerRepository.findByDailyQuestionIdAndUserId(question.getId(), currentUser.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_ANSWER_NOT_FOUND));
+
+        return new DailyAnswerResponseDTO(answer.getId(), question.getId(), question.getContent(), answer.getAnswer(), answer.getCreatedAt());
+    }
+
+    /**
+     * 본인의 히스토리(질문 내용 + 답변) 페이징 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<DailyAnswer> getMyAnswerHistory(User currentUser, Pageable pageable) {
+        return dailyAnswerRepository.findByUserOrderByCreatedAtDesc(currentUser, pageable);
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyQuestionService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyQuestionService.java
@@ -1,0 +1,14 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.service;
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+
+import java.time.LocalDate;
+
+public interface DailyQuestionService {
+
+    public DailyQuestion createOrReplaceForDate(DailyQuestionRequestDTO dto);
+    public DailyQuestion getByDate(LocalDate date);
+    public DailyQuestion getToday();
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyQuestionServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/dailyquestion/service/DailyQuestionServiceImpl.java
@@ -1,0 +1,47 @@
+package com.bigpicture.moonrabbit.domain.dailyquestion.service;
+
+
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionResponseDTO;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyAnswer;
+import com.bigpicture.moonrabbit.domain.dailyquestion.entity.DailyQuestion;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyAnswerRepository;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyQuestionRepository;
+import com.bigpicture.moonrabbit.global.exception.CustomException;
+import com.bigpicture.moonrabbit.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+public class DailyQuestionServiceImpl implements DailyQuestionService{
+    private final DailyQuestionRepository dailyQuestionRepository;
+
+    @Transactional
+    public DailyQuestion createOrReplaceForDate(DailyQuestionRequestDTO dto) {
+        LocalDate date = dto.getDate();
+        String content = dto.getContent();
+
+        DailyQuestion q = dailyQuestionRepository.findByDate(date)
+                .map(existing -> {
+                    existing.updateContent(content);
+                    return existing;
+                })
+                .orElseGet(() -> DailyQuestion.builder().date(date).content(content).build());
+
+        return dailyQuestionRepository.save(q);
+    }
+
+    @Transactional(readOnly = true)
+    public DailyQuestion getByDate(LocalDate date) {
+        return dailyQuestionRepository.findByDate(date)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public DailyQuestion getToday() {
+        return getByDate(LocalDate.now());
+    }
+
+}

--- a/src/main/java/com/bigpicture/moonrabbit/global/config/SpringConfig.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/config/SpringConfig.java
@@ -11,6 +11,10 @@ import com.bigpicture.moonrabbit.domain.board.service.BoardServiceImpl;
 import com.bigpicture.moonrabbit.domain.boardLike.repository.BoardLikeRepository;
 import com.bigpicture.moonrabbit.domain.boardLike.service.BoardLikeService;
 import com.bigpicture.moonrabbit.domain.boardLike.service.BoardLikeServiceImpl;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyAnswerRepository;
+import com.bigpicture.moonrabbit.domain.dailyquestion.repository.DailyQuestionRepository;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyAnswerServiceImpl;
+import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionServiceImpl;
 import com.bigpicture.moonrabbit.domain.example.aiservice.repository.AssistantReplyRepository;
 import com.bigpicture.moonrabbit.domain.example.aiservice.service.AssistantReplyService;
 import com.bigpicture.moonrabbit.domain.example.aiservice.service.AssistantReplyServiceImpl;
@@ -58,6 +62,8 @@ public class SpringConfig {
     private final ReportRepository reportRepository;
     private final UserItemRepository userItemRepository;
     private final ItemRepository itemRepository;
+    private final DailyQuestionRepository dailyQuestionRepository;
+    private final DailyAnswerRepository dailyAnswerRepository;
 
     @Bean
     public UserService userService() {
@@ -112,5 +118,15 @@ public class SpringConfig {
     @Bean
     public UserItemService userItemService() {
         return new UserItemServiceImpl(userItemRepository, userRepository, itemRepository, userService());
+    }
+
+    @Bean
+    public DailyQuestionServiceImpl dailyQuestionService() {
+        return new DailyQuestionServiceImpl(dailyQuestionRepository);
+    }
+
+    @Bean
+    public DailyAnswerServiceImpl dailyAnswerService() {
+        return new DailyAnswerServiceImpl(dailyAnswerRepository, dailyQuestionRepository, userService());
     }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
@@ -29,7 +29,10 @@ public enum ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST,"I001","아이템을 찾을 수 없습니다."),
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST,"I002","아이템을 구매하기 위한 포인트가 부족합니다."),
     ALREADY_OWNED_ITEM(HttpStatus.BAD_REQUEST,"I003","해당 아이템을 이미 보유중입니다."),
-    
+
+    // 일일질문 관련 에러
+    QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST,"Q001","오늘의 질문이 존재하지 않습니다."),
+    QUESTION_ANSWER_NOT_FOUND(HttpStatus.BAD_REQUEST,"Q001","답변이 존재하지 않습니다."),
     // 신고 관련 에러
     ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "R001" ,"이미 신고한 대상입니다." ),
     INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST,"R002" ,"신고 유형이 올바르지 않습니다." ),


### PR DESCRIPTION
# [feat] 일일 질문 기능 구현

## 😺 Issue
- #72 

## ✅ 작업 리스트
- 일일 질문 기능 구현

## ⚙️ 작업 내용
- 관리자 권한 질문 생성/수정
- 오늘의 질문 조회
- 오늘 질문에 답변 제출/수정
- 오늘 내가 쓴 답변 조회
- 내 답변 목록 조회

## 📷 테스트 / 구현 내용
- 관리자 권한 질문 생성/수정

<img width="400" height="174" alt="image" src="https://github.com/user-attachments/assets/d35115c7-9b2f-4307-8ad9-67bac94b6c42" />


- 오늘의 질문 조회

<img width="340" height="192" alt="image" src="https://github.com/user-attachments/assets/f81fa6f9-330c-44b2-9ec9-53efe1cce856" />


- 오늘 질문에 답변 제출/수정

<img width="482" height="196" alt="image" src="https://github.com/user-attachments/assets/15b366ce-8809-4ab9-b59a-41fcac5b2777" />


- 오늘 내가 쓴 답변 조회

<img width="541" height="210" alt="image" src="https://github.com/user-attachments/assets/2b799445-448d-4d2e-a793-7bcb621808e4" />


- 내 답변 목록 조회

<img width="533" height="246" alt="image" src="https://github.com/user-attachments/assets/4e4de51f-d46d-4639-8326-6034ecaf66c1" />


