### PR TITLE
feat: 아이템 전체 조회 기능 추가 및 type 필드 수정

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/controller/ItemController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/controller/ItemController.java
@@ -1,0 +1,33 @@
+package com.bigpicture.moonrabbit.domain.item.controller;
+
+import com.bigpicture.moonrabbit.domain.item.entity.Item;
+import com.bigpicture.moonrabbit.domain.item.service.ItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/items")
+@RequiredArgsConstructor
+@Tag(name = "아이템 상점", description = "아이템 목록 및 상세 조회 API")
+public class ItemController {
+
+    private final ItemService itemService;
+
+    @GetMapping
+    @Operation(summary = "전체 아이템 조회", description = "상점에서 구매 가능한 전체 아이템 목록을 조회합니다.")
+    public Page<Item> getAllItems(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        return itemService.getAllItems(page, size);
+    }
+
+    @GetMapping("/{itemId}")
+    @Operation(summary = "아이템 상세 조회", description = "아이템 상세 정보를 조회합니다.")
+    public Item getItemDetail(@PathVariable Long itemId) {
+        return itemService.getItemDetail(itemId);
+    }
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/entity/ItemType.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/entity/ItemType.java
@@ -1,5 +1,5 @@
 package com.bigpicture.moonrabbit.domain.item.entity;
 
 public enum ItemType {
-    BADGE, NAME_COLOR, OUTLINE_COLOR
+    BADGE, NAME_COLOR, BORDER, BANNER
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemService.java
@@ -1,0 +1,9 @@
+package com.bigpicture.moonrabbit.domain.item.service;
+
+import com.bigpicture.moonrabbit.domain.item.entity.Item;
+import org.springframework.data.domain.Page;
+
+public interface ItemService {
+    Page<Item> getAllItems(int page, int size);
+    Item getItemDetail(Long itemId);
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemServiceImpl.java
@@ -1,0 +1,33 @@
+package com.bigpicture.moonrabbit.domain.item.service;
+
+import com.bigpicture.moonrabbit.domain.item.entity.Item;
+import com.bigpicture.moonrabbit.domain.item.repository.ItemRepository;
+import com.bigpicture.moonrabbit.global.exception.CustomException;
+import com.bigpicture.moonrabbit.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemServiceImpl implements ItemService {
+
+    private final ItemRepository itemRepository;
+
+    @Override
+    public Page<Item> getAllItems(int page, int size) {
+        return itemRepository.findAll(
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"))
+        );
+    }
+
+    @Override
+    public Item getItemDetail(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# [feat] 아이템 전체 조회 기능 추가 및 type 필드 수정

## 😺 Issue
- #81 

## ✅ 작업 리스트
- 전체 아이템 조회 API 추가 (GET /api/items)
- 아이템 상세 조회 API 추가 (GET /api/items/{itemId})
- ItemService 및 ItemServiceImpl 구현
- ItemController 구현 및 Swagger 문서화
- Pageable 기반 페이징 처리 적용

## ⚙️ 작업 내용
ItemController에서 /api/items 엔드포인트를 만들어, ItemService를 통해 DB에서 Page<Item> 형태로 아이템을 가져오도록 했습니다.
ItemServiceImpl에서 findAll(Pageable pageable)을 사용해 페이지 기반으로 아이템을 조회하고, 최신 등록순으로 정렬하도록 구현했습니다.
/api/items/{itemId} 엔드포인트를 추가해 개별 아이템 상세 정보를 조회할 수 있도록 했습니다.

## 📷 테스트 / 구현 내용
- 적용된 테스트 방법과 결과를 이미지나 비디오의 형태로 기록
ex) 단위 테스트 결과, 통합 테스트 진행 및 QA 결과, 관련 스크린샷 첨부