### PR TITLE
[hotfix] 댓글 사용자 아이템 안보이는 오류 수정

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/answer/service/AnswerServiceImpl.java
@@ -113,7 +113,6 @@ public class AnswerServiceImpl implements AnswerService {
     public List<AnswerResponseDTO> getAnswersByBoard(Long boardId, Long currentUserId) {
         List<Answer> answers = answerRepository.findByBoardId(boardId);
 
-        List<EquippedItemDTO> equippedItems = userItemService.getEquippedItems(currentUserId);
         // 기본 정렬이 필요하다면 정렬 추가 (예: 최신순 or 부모-자식 순)
         return answers.stream()
                 .map(answer ->


### PR DESCRIPTION
# [hotfix] 댓글 사용자 아이템 안보이는 오류 수정

## 😺 Issue
- #83 

## ✅ 작업 리스트
- 댓글 사용자 아이템 안보이는 오류 수정

## ⚙️ 작업 내용
- getAnswersByBoard 메서드 수정

## 📷 테스트 / 구현 내용
- 댓글 조회


<img width="1405" height="1020" alt="image" src="https://github.com/user-attachments/assets/67ecb9dc-b8da-45fd-9a07-edf2ee998ffe" />



