### PR TITLE
[feat] 닉네임, 비밀번호 변경 구현

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/controller/UserController.java
@@ -1,11 +1,8 @@
 package com.bigpicture.moonrabbit.domain.user.controller;
 
 
-import com.bigpicture.moonrabbit.domain.user.dto.LoginRequestDTO;
-import com.bigpicture.moonrabbit.domain.user.dto.UserRankingDTO;
-import com.bigpicture.moonrabbit.domain.user.dto.UserRequestDTO;
+import com.bigpicture.moonrabbit.domain.user.dto.*;
 import com.bigpicture.moonrabbit.domain.user.entity.User;
-import com.bigpicture.moonrabbit.domain.user.dto.UserResponseDTO;
 import com.bigpicture.moonrabbit.domain.user.service.UserService;
 import com.bigpicture.moonrabbit.global.auth.jwt.dto.JwtDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -115,4 +112,25 @@ public class UserController {
             @RequestParam(defaultValue = "10") int size) {
         return userService.getTrustPointRanking(page, size);
     }
+    @Operation(summary = "닉네임 변경", description = "로그인된 사용자의 닉네임을 변경합니다.")
+    @PatchMapping("/profile/nickname")
+    public ResponseEntity<UserResponseDTO> updateNickname(@Valid @RequestBody UpdateNicknameRequestDTO requestDTO) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserResponseDTO responseDTO = userService.updateNickname(email, requestDTO.getNewNickname());
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "로그인된 사용자의 비밀번호를 변경합니다.")
+    @PatchMapping("/profile/password")
+    public ResponseEntity<Void> updatePassword(@Valid @RequestBody UpdatePasswordRequestDTO requestDTO) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        userService.updatePassword(
+                email,
+                requestDTO.getCurrentPassword(),
+                requestDTO.getNewPassword(),
+                requestDTO.getNewPasswordConfirm()
+        );
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UpdateNicknameRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UpdateNicknameRequestDTO.java
@@ -1,0 +1,14 @@
+package com.bigpicture.moonrabbit.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNicknameRequestDTO {
+    @NotBlank(message = "새로운 닉네임을 입력해주세요.")
+    @Schema(description = "새로운 닉네임", example = "새로운달토끼")
+    private String newNickname;
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UpdatePasswordRequestDTO.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/dto/UpdatePasswordRequestDTO.java
@@ -1,0 +1,26 @@
+package com.bigpicture.moonrabbit.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePasswordRequestDTO {
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    @Schema(description = "현재 비밀번호", example = "asdf1234!")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
+            message = "비밀번호는 최소 8자 이상이어야 하며, 적어도 하나의 영문자와 하나의 특수 문자를 포함해야 합니다.")
+    @Schema(description = "새 비밀번호", example = "newPassword123!")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+    @Schema(description = "새 비밀번호 확인", example = "newPassword123!")
+    private String newPasswordConfirm;
+
+}

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
@@ -28,4 +28,9 @@ public interface UserService {
     Page<UserRankingDTO> getTotalPointRanking(int page, int size);
 
     Page<UserRankingDTO> getTrustPointRanking(int page, int size);
+
+    // 추가된 메서드
+    UserResponseDTO updateNickname(String email, String newNickname);
+
+    void updatePassword(String email, String currentPassword, String newPassword, String newPasswordConfirm);
 }

--- a/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
+++ b/src/main/java/com/bigpicture/moonrabbit/global/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
 
     // 입력값 검증 에러
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "V001", "잘못된 입력 값입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "V002", "이메일 혹은 비밀번호가 유효하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "V002", "비밀번호가 유효하지 않습니다."),
 
     // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 오류가 발생했습니다."),


### PR DESCRIPTION
# [feat] 닉네임, 비밀번호 변경 구현

## 😺 Issue
- #94 

## ✅ 작업 리스트
- 닉네임, 비밀번호 구현
## ⚙️ 작업 내용
- service 수정, dto 추가, controller 추가

## 📷 테스트 / 구현 내용
- 닉네임 변경

<img width="761" height="222" alt="image" src="https://github.com/user-attachments/assets/4037251f-c5be-444f-b202-096a1f07c445" />

- 비밀번호 변경 실패

<img width="593" height="199" alt="image" src="https://github.com/user-attachments/assets/11a4091e-1a07-4179-be05-05b3c5615f95" />


- 비밀번호 변경 성공

<img width="949" height="261" alt="image" src="https://github.com/user-attachments/assets/bd7f1a92-7f06-4eaa-84a2-d801977fded5" />





