### PR TITLE
[feat] 프로필 이미지 업로드 로직 수정

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserService.java
@@ -33,4 +33,7 @@ public interface UserService {
     UserResponseDTO updateNickname(String email, String newNickname);
 
     void updatePassword(String email, String currentPassword, String newPassword, String newPasswordConfirm);
+
+    // [새로 추가] 프로필 이미지 URL 업데이트 메서드
+    UserResponseDTO updateProfileImage(String email, String newImageUrl);
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/user/service/UserServiceImpl.java
@@ -165,5 +165,13 @@ public class UserServiceImpl implements UserService {
         user.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
     }
+    @Override
+    @Transactional
+    public UserResponseDTO updateProfileImage(String email, String newImageUrl) {
+        User user = getUserByEmail(email);
+        user.setProfileImg(newImageUrl);
+        User savedUser = userRepository.save(user);
+        return new UserResponseDTO(savedUser);
+    }
 
 }


### PR DESCRIPTION
# [feat] 프로필 이미지 업로드 로직 수정

## 😺 Issue
- closes #96 

## ✅ 작업 리스트
- UserService.java, UserServiceImpl.java, UserController.java 수정

## ⚙️ 작업 내용
- UserService.java, UserServiceImpl.java, UserController.java 수정

## 참고 사항 (필요 시)
현재는 단순히 URL만 업데이트합니다. (만약 S3Service의 `updateFile`처럼 이전 이미지 URL을 받아 삭제한다면 로직을 다르게 구성해야 합니다.)