### PR TITLE
[feat] 아이템 수정 삭제 기능 구현

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/admin/controller/AdminController.java
@@ -8,9 +8,12 @@ import com.bigpicture.moonrabbit.domain.board.dto.BoardResponseDTO;
 import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionRequestDTO;
 import com.bigpicture.moonrabbit.domain.dailyquestion.dto.DailyQuestionResponseDTO;
 import com.bigpicture.moonrabbit.domain.dailyquestion.service.DailyQuestionService;
+import com.bigpicture.moonrabbit.domain.item.entity.Item;
+import com.bigpicture.moonrabbit.domain.item.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
     private final AdminService adminService;
     private final DailyQuestionService dailyQuestionService;
+    private final ItemService itemService;
 
     @GetMapping("/users")
     @Operation(summary = "유저 목록 조회", description = "유저들의 목록을 조회하는 기능")
@@ -53,5 +57,24 @@ public class AdminController {
     public AdminResponseDTO deleteBoardAsAdmin(@PathVariable Long boardId) {
         adminService.deleteBoardAsAdmin(boardId);
         return new AdminResponseDTO("게시글 ID : "+boardId+" 삭제되었습니다.");
+    }
+
+    @PutMapping("/items/{itemId}")
+    @Operation(summary = "특정 아이템 정보 수정", description = "관리자가 아이템 이름, 가격, 이미지 등을 수정")
+    public ResponseEntity<Item> updateItemAsAdmin(
+            @PathVariable Long itemId,
+            @RequestParam String name,
+            @RequestParam int price,
+            @RequestParam String imageUrl
+    ) {
+        Item updatedItem = itemService.updateItem(itemId, name, price, imageUrl);
+        return ResponseEntity.ok(updatedItem);
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    @Operation(summary = "특정 아이템 삭제", description = "관리자가 아이템을 영구적으로 삭제")
+    public AdminResponseDTO deleteItemAsAdmin(@PathVariable Long itemId) {
+        itemService.deleteItem(itemId);
+        return new AdminResponseDTO("아이템 ID : "+itemId+" 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/entity/Item.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/entity/Item.java
@@ -3,9 +3,11 @@ package com.bigpicture.moonrabbit.domain.item.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 public class Item {
     @Id

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemService.java
@@ -6,4 +6,8 @@ import org.springframework.data.domain.Page;
 public interface ItemService {
     Page<Item> getAllItems(int page, int size);
     Item getItemDetail(Long itemId);
+
+    Item updateItem(Long itemId, String name, int price, String imageUrl);
+
+    void deleteItem(Long itemId);
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/item/service/ItemServiceImpl.java
@@ -30,4 +30,29 @@ public class ItemServiceImpl implements ItemService {
         return itemRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
     }
+
+    @Override
+    @Transactional
+    public Item updateItem(Long itemId, String newName, int newPrice, String newImageUrl) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
+
+        item.setName(newName);
+        item.setPrice(newPrice);
+        item.setImageUrl(newImageUrl);
+
+        return itemRepository.save(item);
+    }
+
+    @Override
+    @Transactional
+    public void deleteItem(Long itemId) {
+        // 1. 아이템 존재 여부 확인
+        if (!itemRepository.existsById(itemId)) {
+            throw new CustomException(ErrorCode.ITEM_NOT_FOUND);
+        }
+
+        // 2. 아이템 삭제
+        itemRepository.deleteById(itemId);
+    }
 }


### PR DESCRIPTION
# [feat] 아이템 수정 삭제 기능 구현

## 😺 Issue
- #98 

## ✅ 작업 리스트
- 아이템 수정 api 추가
- 아이템 삭제 api 추가 
- 관리자만 접근 가능하도록 설정

## ⚙️ 작업 내용
- Item.java 엔티티 수정 허용으로 변경 및 서비스 인터페이스 내부 updateItem, deleteItem 메서드 추가 후 impl에 트랜잭션 포함한 비지니스 로직 구현
- 관리자 API 엔드포인트 추가 및 ItemService 주입 후 put/delete 매핑 추가

## 📷 테스트 / 구현 내용
<img width="1680" height="1228" alt="image" src="https://github.com/user-attachments/assets/1f3dc6d0-a5e2-49bf-837a-8595ffac1002" />

