### PR TITLE
[feat] 전체 게시글 개수 조회 기능구현

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/controller/BoardController.java
@@ -157,4 +157,13 @@ public class BoardController {
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @Operation(summary = "총 게시글 수 조회", description = "데이터베이스에 저장된 전체 게시글 수를 조회합니다.")
+    @GetMapping("/count/total")
+    public ResponseEntity<Map<String, Long>> getTotalBoardCount() {
+        long count = boardService.getTotalBoardCount();
+        Map<String, Long> response = new HashMap<>();
+        response.put("totalCount", count);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardService.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardService.java
@@ -23,4 +23,6 @@ public interface BoardService {
     BoardResponseDTO toDto(Board board, Long currentUserId);
 
     Page<BoardResponseDTO> selectPagedByUser(Long userId, int page, int size);
+
+    long getTotalBoardCount();
 }

--- a/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/board/service/BoardServiceImpl.java
@@ -1,8 +1,6 @@
 package com.bigpicture.moonrabbit.domain.board.service;
 
 import com.bigpicture.moonrabbit.domain.answer.dto.AnswerResponseDTO;
-import com.bigpicture.moonrabbit.domain.answer.entity.Answer;
-import com.bigpicture.moonrabbit.domain.answer.repository.AnswerRepository;
 import com.bigpicture.moonrabbit.domain.board.dto.BoardRequestDTO;
 import com.bigpicture.moonrabbit.domain.board.dto.BoardResponseDTO;
 import com.bigpicture.moonrabbit.domain.board.entity.Board;
@@ -162,6 +160,11 @@ public class BoardServiceImpl implements BoardService {
 
         return boardRepository.findByUser_Id(userId, pageable)
                 .map(board -> toDto(board, userId));
+    }
+
+    @Override
+    public long getTotalBoardCount() {
+        return boardRepository.count();
     }
 }
 


### PR DESCRIPTION
# [feat] 전체 게시글 개수 조회 기능구현

## 😺 Issue
- #104 

## ✅ 작업 리스트
- board 도메인 내부 서비스 및 컨트롤러 수정

## ⚙️ 작업 내용
- 전체 게시글 수를 반환하는 메서드 설계 및 count() 사용해서 계산

## 📷 테스트 / 구현 내용
<img width="1698" height="1008" alt="image" src="https://github.com/user-attachments/assets/cc739fc8-5eb1-4235-8da5-d7cb3a022737" />