### PR TITLE
[fix] OCR 배포 오류 수정

### DIFF
--- a/src/main/java/com/bigpicture/moonrabbit/domain/ocr/service/OcrPdfProcessor.java
+++ b/src/main/java/com/bigpicture/moonrabbit/domain/ocr/service/OcrPdfProcessor.java
@@ -5,7 +5,7 @@ import net.sourceforge.tess4j.Tesseract;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.stereotype.Service;
-
+import org.springframework.beans.factory.annotation.Value;
 import jakarta.annotation.PostConstruct;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -18,18 +18,22 @@ public class OcrPdfProcessor {
     private final ChatModel chatModel;
     private final BlockingQueue<Tesseract> tesseractPool = new ArrayBlockingQueue<>(Runtime.getRuntime().availableProcessors());
 
-    public OcrPdfProcessor(ChatModel chatModel) {
+    private final String tessPath;
+
+    // 생성자에서 경로를 @Value로 주입받도록 변경
+    public OcrPdfProcessor(ChatModel chatModel, @Value("${tesseract.datapath}") String tessPath) {
         this.chatModel = chatModel;
+        this.tessPath = tessPath;
     }
 
     @PostConstruct
     public void initPool() {
         int poolSize = Runtime.getRuntime().availableProcessors();
-        String tessPath = "C:\\Program Files\\Tesseract-OCR\\tessdata\\";
+//        String tessPath = "C:\\Program Files\\Tesseract-OCR\\tessdata\\";
 
         for (int i = 0; i < poolSize; i++) {
             Tesseract t = new Tesseract();
-            t.setDatapath(tessPath);
+            t.setDatapath(this.tessPath);
             t.setLanguage("kor+eng");
             tesseractPool.add(t);
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,7 +67,6 @@ aws.region=ap-northeast-2
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB
 
-
 # SPRING TIMEOUT
 spring.mvc.async.request-timeout=600000
 
@@ -75,3 +74,6 @@ spring.mvc.async.request-timeout=600000
 spring.output.ansi.enabled=ALWAYS
 spring.main.banner-mode=console
 logging.charset.console=UTF-8
+
+# Tesseract Data Path
+tesseract.datapath=/usr/share/tesseract/tessdata/


### PR DESCRIPTION
# [fix] OCR 배포 오류 수정

## 😺 Issue
- #106 

## ✅ 작업 리스트
- OCR 배포 오류 관련 경로 변경
- 컨트롤러 수정

## ⚙️ 작업 내용
- 기존 tesseract 경로를 하드코딩된 `String tessPath = "C:\\Program Files\\Tesseract-OCR\\tessdata\\"; ` 값으로 전달에서 리눅스 경로로 수정